### PR TITLE
build(deps): revert prettier to 2.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint-staged": "^13.2.3",
     "nuxt": "^3.6.1",
     "nuxt-icon": "^0.4.2",
-    "prettier": "3.0.0",
+    "prettier": "2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",
     "typescript": "^5.1.6",
     "vue-tsc": "^1.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,11 +80,11 @@ devDependencies:
     specifier: ^0.4.2
     version: 0.4.2(vue@3.3.4)
   prettier:
-    specifier: 3.0.0
-    version: 3.0.0
+    specifier: 2.8.8
+    version: 2.8.8
   prettier-plugin-tailwindcss:
     specifier: ^0.3.0
-    version: 0.3.0(prettier@3.0.0)
+    version: 0.3.0(prettier@2.8.8)
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
@@ -7074,7 +7074,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-tailwindcss@0.3.0(prettier@3.0.0):
+  /prettier-plugin-tailwindcss@0.3.0(prettier@2.8.8):
     resolution: {integrity: sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA==}
     engines: {node: '>=12.17.0'}
     peerDependencies:
@@ -7126,12 +7126,12 @@ packages:
       prettier-plugin-twig-melody:
         optional: true
     dependencies:
-      prettier: 3.0.0
+      prettier: 2.8.8
     dev: true
 
-  /prettier@3.0.0:
-    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
-    engines: {node: '>=14'}
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
since `prettier-plugin-tailwindcss` was not supported, track: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/176