### PR TITLE
fix: inconsistency in monthpicker & quick navigation

### DIFF
--- a/components/PageCalendar/PageCalendarQuickNavigation.client.vue
+++ b/components/PageCalendar/PageCalendarQuickNavigation.client.vue
@@ -9,19 +9,16 @@ const floatingButton = {
 };
 
 const props = defineProps<{
-  modelValue: number;
-  length: number;
-}>();
-const emit = defineEmits<{
-  "update:modelValue": [number];
+  currentDay: string;
+  dates: string[];
+  scroll: (position: string) => void;
 }>();
 
 const scrollUp = () =>
-  props.modelValue > 0 && emit("update:modelValue", props.modelValue - 1);
+  props.scroll(props.dates[props.dates.indexOf(props.currentDay) - 1]);
 const scrollDown = () =>
-  props.modelValue < props.length &&
-  emit("update:modelValue", props.modelValue + 1);
-const scrollToTop = () => emit("update:modelValue", 0);
+  props.scroll(props.dates[props.dates.indexOf(props.currentDay) + 1]);
+const scrollToTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
 </script>
 
 <template>
@@ -31,7 +28,7 @@ const scrollToTop = () => emit("update:modelValue", 0);
     <UButton
       color="gray"
       icon="i-fluent-chevron-up-20-filled"
-      :disabled="modelValue === 0"
+      :disabled="dates.indexOf(currentDay) === 0"
       square
       :ui="floatingButton"
       @click="scrollUp"
@@ -48,7 +45,7 @@ const scrollToTop = () => emit("update:modelValue", 0);
     <UButton
       color="gray"
       icon="i-fluent-chevron-down-20-filled"
-      :disabled="modelValue === length - 1"
+      :disabled="dates.indexOf(currentDay) === dates.length - 1"
       square
       :ui="floatingButton"
       @click="scrollDown"

--- a/components/PageCalendar/PageCalendarToolbar.vue
+++ b/components/PageCalendar/PageCalendarToolbar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { joinURL } from "ufo";
-import dayjs, { type Dayjs } from "dayjs";
+import { type Dayjs } from "dayjs";
 import type { FilterPublishers } from "@/utils/releases";
 import { Collections, type PublisherResponse } from "@/types/pb";
 
@@ -37,8 +37,8 @@ const emit = defineEmits<{
 }>();
 
 const currentMonth = computed({
-  get: () => props.month.toDate(),
-  set: (value) => emit("update:month", dayjs.utc(value)),
+  get: () => props.month,
+  set: (value) => emit("update:month", value),
 });
 
 const currentPublishers = computed({

--- a/plugins/dayjs.ts
+++ b/plugins/dayjs.ts
@@ -1,11 +1,13 @@
 /* eslint-disable import/no-named-as-default-member */
 import dayjs from "dayjs";
 import localeData from "dayjs/plugin/localeData";
+import objectSupport from "dayjs/plugin/objectSupport";
 import utc from "dayjs/plugin/utc";
 import "dayjs/locale/vi";
 
 export default defineNuxtPlugin((_) => {
   dayjs.extend(localeData);
   dayjs.extend(utc);
+  dayjs.extend(objectSupport);
   dayjs.locale("vi");
 });

--- a/utils/releases.ts
+++ b/utils/releases.ts
@@ -57,7 +57,7 @@ export const getCalendarReleases = async (
     }>
   >({
     filter: filter.join(" && "),
-    sort: "+publishDate",
+    sort: "+publishDate,+name,-edition",
     expand: "title, publisher",
   });
 


### PR DESCRIPTION
This PR fixes how `<AppMonthPicker />` was giving out wrong month (as it was created using client's local time), and quick navigation being slow and reversed at some time (due to Vue's nature of `v-for` refs, check [documentation](https://vuejs.org/guide/essentials/template-refs.html#refs-inside-v-for)).

Quick navigation now uses client-side calculation (using `document` selectors and array location) instead of navigating with Vue's refs.