### PR TITLE
feat(nav): add calendar link on mobile

### DIFF
--- a/components/TheNavigation/TheNavigation.vue
+++ b/components/TheNavigation/TheNavigation.vue
@@ -62,6 +62,14 @@ withDefaults(
 
       <div class="flex items-center justify-end gap-3 whitespace-nowrap">
         <TheSearchToggle />
+        <UButton
+          class="sm:hidden"
+          color="gray"
+          variant="ghost"
+          icon="i-fluent-calendar-20-filled"
+          to="/calendar"
+          square
+        />
         <TheNavigationUser />
       </div>
     </div>


### PR DESCRIPTION
this PR reduce the number of action it takes to navigate to `/calendar` on mobile (from open nav -> calendar to just pressing the little calendar icon)