### PR TITLE
fix(title): add sort to cover images

### DIFF
--- a/utils/title.ts
+++ b/utils/title.ts
@@ -21,6 +21,7 @@ export async function getTitleCoverImages(id: string) {
     >({
       filter: `title='${id}'`,
       fields: "id,collectionId,edition,cover,baseCover",
+      sort: "+edition,+volume",
     });
 
   data.forEach(({ id, collectionId, edition, cover, baseCover }) => {


### PR DESCRIPTION
### Before
Not correctly sorted
![image](https://github.com/tanamoe/kikuri/assets/12823486/3ade0682-722c-462e-bc2e-a22ac553b082)
![image](https://github.com/tanamoe/kikuri/assets/12823486/c7430634-ea91-44e8-b500-05d3e91ac90a)

### After
Sorted with +edition and +volume
![image](https://github.com/tanamoe/kikuri/assets/12823486/cf25edf1-e3fb-4366-99a9-c399b3b0baa9)
![image](https://github.com/tanamoe/kikuri/assets/12823486/ff47e83d-698c-4180-ac39-61b5c4672258)