### PR TITLE
feat: add `touch-action: none` to quick navigation up down button

### DIFF
--- a/components/page/calendar/PageCalendarQuickNavigation.vue
+++ b/components/page/calendar/PageCalendarQuickNavigation.vue
@@ -73,6 +73,7 @@ onUnmounted(() => {
     <div class="flex gap-3">
       <UButton
         color="gray"
+        class="touch-none"
         icon="i-fluent-chevron-up-20-filled"
         :disabled="dates.indexOf(position) === -1"
         square
@@ -99,6 +100,7 @@ onUnmounted(() => {
       </UButton>
       <UButton
         color="gray"
+        class="touch-none"
         icon="i-fluent-chevron-down-20-filled"
         :disabled="dates.indexOf(position) === dates.length - 0"
         square


### PR DESCRIPTION
this is to prevent zoom on clicking way too fast on mobile devices